### PR TITLE
ci: publish Docker image to Docker Hub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,12 @@
 name: Docker Image
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 0 * * *' # Run every day at midnight
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -14,7 +17,8 @@ permissions:
   packages: write
 
 env:
-  REGISTRY_IMAGE: ghcr.io/beeman/solana-test-validator
+  DOCKERHUB_IMAGE: beeman/solana-test-validator
+  GHCR_IMAGE: ghcr.io/beeman/solana-test-validator
 
 jobs:
   prepare:
@@ -55,6 +59,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -67,7 +78,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: ${{ env.GHCR_IMAGE }}
           tags: |
             type=raw,value=${{ needs.prepare.outputs.agave_version }}
             type=raw,value=latest,priority=1024
@@ -91,7 +102,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           build-args: AGAVE_VERSION=${{ needs.prepare.outputs.agave_version }}
 
       - name: Export digest
@@ -128,7 +139,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY_IMAGE }}
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
           tags: |
             type=raw,value=${{ needs.prepare.outputs.agave_version }}
             type=raw,value=latest,priority=1024
@@ -144,6 +157,13 @@ jobs:
             org.opencontainers.image.title=Solana Test Validator
             org.opencontainers.image.version=${{ needs.prepare.outputs.agave_version }}
 
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -156,8 +176,9 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
 
-      - name: Inspect image
+      - name: Inspect images
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository contains a Docker image for the Solana Test Validator.
 
+## Docker Image
+
+```shell
+beeman/solana-test-validator
+```
+
+Also available on GitHub Container Registry as `ghcr.io/beeman/solana-test-validator`.
+
 This Docker image is built each night for `linux/amd64` as well as `linux/arm64` platforms.
 
 This makes it possible to run this image on devices with Apple Silicon processors.
@@ -11,7 +19,7 @@ This makes it possible to run this image on devices with Apple Silicon processor
 To run the Solana Test Validator, you can use the following command:
 
 ```shell
-docker run --security-opt seccomp=unconfined -it -p 8899:8899 -p 8900:8900 --rm --name solana-test-validator ghcr.io/beeman/solana-test-validator:latest
+docker run --security-opt seccomp=unconfined -it -p 8899:8899 -p 8900:8900 --rm --name solana-test-validator beeman/solana-test-validator:latest
 ```
 
 This will start the Solana Test Validator on port 8899 and 8900.
@@ -23,7 +31,7 @@ See the [examples](https://github.com/beeman/solana-test-validator/tree/main/exa
 Agave v2.0+ uses `io_uring` to significantly improve snapshot unpacking performance (see [PR #6535](https://github.com/anza-xyz/agave/pull/6535)). Docker's default security profile (`seccomp`) blocks necessary syscalls (like `io_uring_setup`), causing the validator to fail. Using `--security-opt seccomp=unconfined` (or a custom profile) is required to allow these syscalls.
 
 ```sh
-docker run --security-opt seccomp=unconfined ghcr.io/beeman/solana-test-validator:latest
+docker run --security-opt seccomp=unconfined beeman/solana-test-validator:latest
 # alternatively, create a seccomp profile that allows io_uring and other required syscalls
 ```
 
@@ -35,7 +43,7 @@ To build the Docker image, you can use the following command using [just](https:
 just build
 ```
 
-This will build the Docker image and tag it as `ghcr.io/beeman/solana-test-validator`.
+This will build the Docker image and tag it as `beeman/solana-test-validator`.
 
 ## Running the Docker image
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -10,7 +10,7 @@ Agave v2.0+ uses `io_uring` to significantly improve snapshot unpacking performa
 # docker-compose.yml
 services:
   validator:
-    image: ghcr.io/beeman/solana-test-validator:latest
+    image: beeman/solana-test-validator:latest
     # Clone the Metaplex program from the Solana Devnet cluster
     command: "solana-test-validator --url https://api.devnet.solana.com --clone metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s --clone PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT"
     ports:

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   validator:
-    image: ghcr.io/beeman/solana-test-validator:latest
+    image: beeman/solana-test-validator:latest
     # Clone the Metaplex program from the Solana Devnet cluster
     command: "solana-test-validator --url https://api.devnet.solana.com --clone metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s --clone PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT"
     ports:

--- a/examples/dockerfile/Dockerfile
+++ b/examples/dockerfile/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/beeman/solana-test-validator:latest
+FROM beeman/solana-test-validator:latest
 # Clone the Metaplex program from the Solana Devnet cluster
 CMD ["solana-test-validator", "--url", "https://api.devnet.solana.com", "--clone", "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s", "--clone", "PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT"]

--- a/examples/dockerfile/README.md
+++ b/examples/dockerfile/README.md
@@ -3,7 +3,7 @@
 You can use this image in a custom Docker image like so:
 
 ```dockerfile
-FROM ghcr.io/beeman/solana-test-validator:latest
+FROM beeman/solana-test-validator:latest
 # Clone the Metaplex program from the Solana Devnet cluster
 CMD ["solana-test-validator", "--url", "https://api.devnet.solana.com", "--clone", "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s", "--clone", "PwDiXFxQsGra4sFFTT8r1QWRMd4vfumiWC1jfWNfdYT"]
 ```

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 CONTAINER_NAME := "solana-test-validator"
 CONTAINER_PARAMS := "--security-opt seccomp=unconfined -it -p 8899:8899 -p 8900:8900 --rm"
-DOCKER_USER := "ghcr.io/beeman"
+DOCKER_USER := "beeman"
 DOCKER_REPO := "solana-test-validator"
 DOCKER_TAG := "latest"
 


### PR DESCRIPTION
Publish the nightly multi-arch image manifest to Docker Hub alongside GHCR.

Make Docker Hub the default image name in the README, examples, and local just commands.
